### PR TITLE
Adopt new regex.yaml format (with regex flag, device band and model)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC=g++
-LDFLAGS=-lboost_regex -lboost_system -lyaml-cpp -lglog
+LDFLAGS=-lboost_regex -lboost_system -lyaml-cpp -lglog -fPIC
 CFLAGS=-std=c++0x -Wall -Werror -g -O3
 
 # wildcard object build target
@@ -12,6 +12,9 @@ uaparser_cpp: libuaparser_cpp.a
 libuaparser_cpp.a: UaParser.o
 	ar rcs $@ $^
 
+libuaparser_cpp.so: UaParser.o
+	$(CC) $< -shared $(LDFLAGS) -o $@
+
 UaParserTest: libuaparser_cpp.a UaParserTest.o
 	$(CC) $(CFLAGS) $^ -o $@ libuaparser_cpp.a $(LDFLAGS) -lgtest -lpthread
 
@@ -22,7 +25,7 @@ test: UaParserTest
 clean:
 	find . -name "*.o" -exec rm -rf {} \; # clean up object files
 	find . -name "*.d" -exec rm -rf {} \; # clean up dependencies
-	rm -f UaParserTest *.a
+	rm -f UaParserTest *.a *.so
 
 # automatically include the generated *.d dependency make targets
 # that are created from the wildcard %.o build target above

--- a/UaParser.cpp
+++ b/UaParser.cpp
@@ -6,6 +6,7 @@
 #include <unordered_set>
 
 #include <boost/regex.hpp>
+#include <boost/algorithm/string.hpp>
 #include <glog/logging.h>
 #include <yaml-cpp/yaml.h>
 
@@ -36,7 +37,8 @@ typedef AgentStore BrowserStore;
       const auto key = it->first.as<std::string>();                      \
       const auto value = it->second.as<std::string>();                   \
       if (key == "regex") {                                              \
-        agent_store.regExpr = value;                                     \
+        agent_store.regExpr.assign(value,                                \
+          boost::regex::optimize);                                       \
       } else if (key == repl) {                                          \
         agent_store.replacement = value;                                 \
       } else if (key == maj_repl && !value.empty()) {                    \
@@ -77,10 +79,10 @@ struct UAStore {
         const auto key = it->first.as<std::string>();
         const auto value = it->second.as<std::string>();
         if (key == "regex") {
-          device.regExpr.assign(value);
-        } else if ( key == "regex_flag") {
-            if ( value == "i")
-              device.regExpr.assign(device.regExpr.str(), boost::regex::icase);
+          device.regExpr.assign(value, boost::regex::optimize);
+        }
+        else if ( key == "regex_flag" && value == "i" ) {
+          device.regExpr.assign(device.regExpr.str(), boost::regex::optimize|boost::regex::icase);
         } else if (key == "device_replacement") {
           device.replacement = value;
         } else if (key == "model_replacement") {
@@ -105,60 +107,30 @@ struct UAStore {
 // HELPERS //
 /////////////
 
-void find_and_replace(std::string &original, const std::string &tofind, const std::string &toreplace) {
-    std::string::size_type loc = original.find(tofind);
-    if (loc == std::string::npos) {
-        return;
-    }
-
-    //Because there can be spaces leading the replacement symbol " $1" and when toreplace is empty
-    // This can lead to multiple spaces e.g.: "HTC Desire   " or "HTC   Desire"
-    //   But you want to avoid the case of "HTC $1$2" where $2 is not empty but $2 , you don't wan't "HTCxyz"
-    // If you're replacing empty:
-    //   If you have a leading whitespace
-    //     If the next character after the placeholder (loc+2) is also a white space OR it's the end of the string
-    //       Then get rid of the leading whitespace
-    if (toreplace.size()==0) {
-        if (loc != 0 && original[loc-1] == ' ') {
-            if( (loc+2 < original.size() && original[loc+2]==' ') || (loc+2 >= original.size()) ) {
-                original.replace(loc-1, tofind.size()+1, toreplace);
-                return;
-            }
-        }
-    }
-    //Otherwise just do a normal replace
-    original.replace(loc, tofind.size(), toreplace);
-}
-
-
 //Device parsing is different than the other parsing in that a field can have many placeholders
 const char* placeholders[]= {"$1", "$2", "$3", "$4","$5", "$6", "$7", "$8", "$9"};
 void replace_all_placeholders(std::string& device_property, const boost::smatch &result) {
+    std::string::size_type loc;
     for (unsigned int idx = 1; idx < result.size(); ++idx) {
-        std::string replacement;
-        try {
-            replacement = result[idx].str();
+        loc = device_property.find(placeholders[idx-1]);
+        if ( loc != std::string::npos ) {
+            if ( result[idx].matched ) {
+              device_property.replace(loc,2,result[idx].str());
+            }
+            else
+              device_property.erase(loc,2);
         }
-        catch (std::length_error &e) {
-            replacement = std::string("");
-        }
-        find_and_replace(device_property, placeholders[idx-1], replacement);
     }
+
+    // There should not be placehoders leftover. This is a Workaround ...
+    loc = device_property.find_first_of('$');
+    if ( loc != std::string::npos )
+      device_property.erase(loc,device_property.size());
     return;
 }
 
 
-void remove_trailing_whitespaces(std::string &original) {
-    //Sometimes te regexes don't actually parse correctly leaving trailing whitespaces
-    //The if statment is so that we don't always do a find.
-    if (original.back()== ' ') {
-        size_t pos = original.find_last_not_of(' ');
-        if (pos != std::string::npos) {
-            original.resize(pos+1);
-        }
-    }
-    return;
-}
+
 
 template<class AGENT, class AGENT_STORE>
 void fillAgent(AGENT& agent, const AGENT_STORE& store, const boost::smatch& m) {
@@ -225,40 +197,34 @@ UserAgent parseImpl(const std::string& ua, const UAStore* ua_store) {
   for (const auto& d : ua_store->deviceStore) {
     auto& device = uagent.device;
     boost::smatch m;
+
     if (boost::regex_search(ua, m, d.regExpr)) {
-
-      if ( d.replacement.empty() && m.size() == 1 ){
-        device.family = m[0].str();
-      }
-      else if (d.replacement.empty() && m.size() > 1) {
-        device.family = m[1].str();
-      }
-      else{
-        device.family = d.replacement;
-        replace_all_placeholders(device.family, m);
-        device.family = boost::regex_replace(device.family, boost::regex("\\$[0-9]"),"");
-        remove_trailing_whitespaces(device.family);
-      }
-
-     if (d.brand_replacement.empty() && m.size() > 2) {
-        device.brand = m[2].str();
+      if ( d.replacement.empty() && m.size() > 1 ) {
+          device.family = m[1].str();
       }
       else {
-        device.brand = d.brand_replacement;
-        replace_all_placeholders(device.brand, m);
-        remove_trailing_whitespaces(device.brand);
+        device.family = d.replacement;
+        replace_all_placeholders(device.family, m);
+        boost::algorithm::trim(device.family);
       }
 
-      if (d.model_replacement.empty() && m.size() > 3) {
-         device.model = m[3].str();
-       }
-       else {
-         device.model = d.model_replacement;
-         replace_all_placeholders(device.model, m);
-         remove_trailing_whitespaces(device.model);
-       }
+      if ( ! d.brand_replacement.empty() )
+      {
+        device.brand = d.brand_replacement;
+        replace_all_placeholders(device.brand, m);
+        boost::algorithm::trim(device.brand);
+      }
 
-       break;
+      if (d.model_replacement.empty() && m.size() > 1) {
+           device.model = m[1].str();
+      }
+      else {
+           device.model = d.model_replacement;
+           replace_all_placeholders(device.model, m);
+           boost::algorithm::trim(device.model);
+      }
+
+      break;
     } else {
       device.family = "Other";
     }

--- a/UaParser.cpp
+++ b/UaParser.cpp
@@ -12,21 +12,21 @@
 
 namespace {
 
-  struct GenericStore {
-      std::string replacement;
-      boost::regex regExpr;
-  };
+struct GenericStore {
+  std::string replacement;
+  boost::regex regExpr;
+};
 
-  struct DeviceStore : GenericStore {
-    std::string brand_replacement;
-    std::string model_replacement;
-    boost::regex regExpr;
-  };
+struct DeviceStore : GenericStore {
+  std::string brandReplacement;
+  std::string modelReplacement;
+  boost::regex regExpr;
+};
 
-  struct AgentStore : GenericStore {
-    std::string majorVersionReplacement;
-    std::string minorVersionReplacement;
-  };
+struct AgentStore : GenericStore {
+  std::string majorVersionReplacement;
+  std::string minorVersionReplacement;
+};
 
 typedef AgentStore OsStore;
 typedef AgentStore BrowserStore;
@@ -86,9 +86,9 @@ struct UAStore {
         } else if (key == "device_replacement") {
           device.replacement = value;
         } else if (key == "model_replacement") {
-          device.model_replacement = value;
+          device.modelReplacement = value;
         } else if (key == "brand_replacement") {
-          device.brand_replacement = value;
+          device.brandReplacement = value;
         } else {
           CHECK(false);
         }
@@ -108,25 +108,24 @@ struct UAStore {
 /////////////
 
 //Device parsing is different than the other parsing in that a field can have many placeholders
-const char* placeholders[]= {"$1", "$2", "$3", "$4","$5", "$6", "$7", "$8", "$9"};
+const char* placeholders[] = {"$1", "$2", "$3", "$4", "$5", "$6", "$7", "$8", "$9"};
 void replace_all_placeholders(std::string& device_property, const boost::smatch &result) {
-    std::string::size_type loc;
-    for (unsigned int idx = 1; idx < result.size(); ++idx) {
-        loc = device_property.find(placeholders[idx-1]);
-        if ( loc != std::string::npos ) {
-            if ( result[idx].matched ) {
-              device_property.replace(loc,2,result[idx].str());
-            }
-            else
-              device_property.erase(loc,2);
-        }
+  std::string::size_type loc;
+  for (size_t idx = 1; idx < result.size(); ++idx) {
+    loc = device_property.find(placeholders[idx-1]);
+    if (loc != std::string::npos) {
+      if (result[idx].matched) {
+        device_property.replace(loc,2,result[idx].str());
+      }
+      else
+        device_property.erase(loc,2);
     }
-
-    // There should not be placehoders leftover. This is a Workaround ...
-    loc = device_property.find_first_of('$');
-    if ( loc != std::string::npos )
-      device_property.erase(loc,device_property.size());
-    return;
+  }
+  // There should not be placehoders leftover. This is a Workaround ...
+  loc = device_property.find_first_of('$');
+  if ( loc != std::string::npos )
+    device_property.erase(loc,device_property.size());
+  return;
 }
 
 
@@ -199,37 +198,32 @@ UserAgent parseImpl(const std::string& ua, const UAStore* ua_store) {
     boost::smatch m;
 
     if (boost::regex_search(ua, m, d.regExpr)) {
-      if ( d.replacement.empty() && m.size() > 1 ) {
-          device.family = m[1].str();
-      }
-      else {
+      if ( d.replacement.empty() && m.size() > 1) {
+        device.family = m[1].str();
+      } else {
         device.family = d.replacement;
         replace_all_placeholders(device.family, m);
         boost::algorithm::trim(device.family);
       }
 
-      if ( ! d.brand_replacement.empty() )
-      {
-        device.brand = d.brand_replacement;
+      if ( ! d.brandReplacement.empty() ) {
+        device.brand = d.brandReplacement;
         replace_all_placeholders(device.brand, m);
         boost::algorithm::trim(device.brand);
       }
 
-      if (d.model_replacement.empty() && m.size() > 1) {
-           device.model = m[1].str();
+      if (d.modelReplacement.empty() && m.size() > 1) {
+        device.model = m[1].str();
+      } else {
+          device.model = d.modelReplacement;
+          replace_all_placeholders(device.model, m);
+          boost::algorithm::trim(device.model);
       }
-      else {
-           device.model = d.model_replacement;
-           replace_all_placeholders(device.model, m);
-           boost::algorithm::trim(device.model);
-      }
-
       break;
     } else {
       device.family = "Other";
     }
   }
-
   return uagent;
 }
 

--- a/UaParser.h
+++ b/UaParser.h
@@ -2,11 +2,16 @@
 
 #include <string>
 
-struct Device {
+struct Generic {
   std::string family;
 };
 
-struct Agent : Device {
+struct Device : Generic {
+  std::string model;
+  std::string brand;
+};
+
+struct Agent : Generic {
   std::string major;
   std::string minor;
   std::string patch;

--- a/UaParserTest.cpp
+++ b/UaParserTest.cpp
@@ -81,8 +81,10 @@ void test_device(const std::string file_path) {
     EXPECT_EQ(model, uagent.device.model);
 
     test_counter++;
-    if ( uagent.device.family == family && uagent.device.brand == brand && uagent.device.model == model )
-        passed_counter++;
+    if (uagent.device.family == family &&
+        uagent.device.brand == brand &&
+        uagent.device.model == model)
+      passed_counter++;
     else
       std::cout << unparsed << std::endl;
   }
@@ -102,7 +104,6 @@ TEST(OsVersion, test_ua) {
   test_browser_or_os(UA_CORE_DIR+"/tests/test_ua.yaml", true);
 }
 
-
 TEST(BrowserVersion, firefox_user_agent_strings) {
   test_browser_or_os(UA_CORE_DIR+"/test_resources/firefox_user_agent_strings.yaml", true);
 }
@@ -118,8 +119,6 @@ TEST(OsVersion, additional_os_tests) {
 TEST(DeviceFamily, test_device) {
   test_device(UA_CORE_DIR+"/tests/test_device.yaml");
 }
-
-
 
 }  // namespace
 

--- a/UaParserTest.cpp
+++ b/UaParserTest.cpp
@@ -7,7 +7,9 @@
 
 namespace {
 
-const UserAgentParser g_ua_parser("../regexes.yaml");
+static const std::string UA_CORE_DIR="../uap-core";
+
+const UserAgentParser g_ua_parser(UA_CORE_DIR + "/regexes.yaml");
 
 TEST(UserAgentParser, basic) {
   const auto uagent = g_ua_parser.parse(
@@ -16,7 +18,7 @@ TEST(UserAgentParser, basic) {
   ASSERT_EQ("Mobile Safari", uagent.browser.family);
   ASSERT_EQ("5", uagent.browser.major);
   ASSERT_EQ("1", uagent.browser.minor);
-  ASSERT_EQ("", uagent.browser.patch);
+  ASSERT_EQ("0", uagent.browser.patch);
   ASSERT_EQ("Mobile Safari 5.1.0", uagent.browser.toString());
   ASSERT_EQ("5.1.0", uagent.browser.toVersionString());
 
@@ -41,7 +43,7 @@ std::string string_field(const YAML::Node& root, const std::string& fname) {
   return yaml_field.IsNull() ? "" : yaml_field.as<std::string>();
 }
 
-void test_browser_or_os(const char* file_path, const bool browser) {
+void test_browser_or_os(const std::string file_path, const bool browser) {
   auto root = YAML::LoadFile(file_path);
   const auto& test_cases = root["test_cases"];
   for (const auto& test : test_cases) {
@@ -63,7 +65,7 @@ void test_browser_or_os(const char* file_path, const bool browser) {
   }
 }
 
-void test_device(const char* file_path) {
+void test_device(const std::string file_path) {
   auto root = YAML::LoadFile(file_path);
   const auto& test_cases = root["test_cases"];
   for (const auto& test : test_cases) {
@@ -77,27 +79,27 @@ void test_device(const char* file_path) {
 }  // namespace
 
 TEST(BrowserVersion, test_user_agent_parser) {
-  test_browser_or_os("../test_resources/test_user_agent_parser.yaml", true);
+  test_browser_or_os(UA_CORE_DIR+"/test_resources/test_user_agent_parser.yaml", true);
 }
 
 TEST(BrowserVersion, firefox_user_agent_strings) {
-  test_browser_or_os("../test_resources/firefox_user_agent_strings.yaml", true);
+  test_browser_or_os(UA_CORE_DIR+"/test_resources/firefox_user_agent_strings.yaml", true);
 }
 
 TEST(BrowserVersion, pgts_browser_list) {
-  test_browser_or_os("../test_resources/pgts_browser_list.yaml", true);
+  test_browser_or_os(UA_CORE_DIR+"/test_resources/pgts_browser_list.yaml", true);
 }
 
 TEST(OsVersion, test_user_agent_parser_os) {
-  test_browser_or_os("../test_resources/test_user_agent_parser_os.yaml", false);
+  test_browser_or_os(UA_CORE_DIR+"/test_resources/test_user_agent_parser_os.yaml", false);
 }
 
 TEST(OsVersion, additional_os_tests) {
-  test_browser_or_os("../test_resources/additional_os_tests.yaml", false);
+  test_browser_or_os(UA_CORE_DIR+"/test_resources/additional_os_tests.yaml", false);
 }
 
 TEST(DeviceFamily, test_device) {
-  test_device("../test_resources/test_device.yaml");
+  test_device(UA_CORE_DIR+"/test_resources/test_device.yaml");
 }
 
 }  // namespace

--- a/UaParserTest.cpp
+++ b/UaParserTest.cpp
@@ -18,7 +18,7 @@ TEST(UserAgentParser, basic) {
   ASSERT_EQ("Mobile Safari", uagent.browser.family);
   ASSERT_EQ("5", uagent.browser.major);
   ASSERT_EQ("1", uagent.browser.minor);
-  ASSERT_EQ("0", uagent.browser.patch);
+  ASSERT_EQ("", uagent.browser.patch);
   ASSERT_EQ("Mobile Safari 5.1.0", uagent.browser.toString());
   ASSERT_EQ("5.1.0", uagent.browser.toVersionString());
 
@@ -68,19 +68,40 @@ void test_browser_or_os(const std::string file_path, const bool browser) {
 void test_device(const std::string file_path) {
   auto root = YAML::LoadFile(file_path);
   const auto& test_cases = root["test_cases"];
+  unsigned int passed_counter = 0, test_counter = 0;
   for (const auto& test : test_cases) {
     const auto unparsed = string_field(test, "user_agent_string");
     const auto uagent = g_ua_parser.parse(unparsed);
     const auto family = string_field(test, "family");
-    ASSERT_EQ(family, uagent.device.family);
+    const auto brand = string_field(test, "brand");
+    const auto model = string_field(test, "model");
+
+    EXPECT_EQ(family, uagent.device.family);
+    EXPECT_EQ(brand, uagent.device.brand);
+    EXPECT_EQ(model, uagent.device.model);
+
+    test_counter++;
+    if ( uagent.device.family == family && uagent.device.brand == brand && uagent.device.model == model )
+        passed_counter++;
+    else
+      std::cout << unparsed << std::endl;
   }
+
+  std::cout << "Device tests passed: " <<  passed_counter << "/" << test_counter << std::endl;
 }
 
 }  // namespace
 
-TEST(BrowserVersion, test_user_agent_parser) {
-  test_browser_or_os(UA_CORE_DIR+"/test_resources/test_user_agent_parser.yaml", true);
+
+
+TEST(OsVersion, test_os) {
+  test_browser_or_os(UA_CORE_DIR+"/tests/test_os.yaml", false);
 }
+
+TEST(OsVersion, test_ua) {
+  test_browser_or_os(UA_CORE_DIR+"/tests/test_ua.yaml", true);
+}
+
 
 TEST(BrowserVersion, firefox_user_agent_strings) {
   test_browser_or_os(UA_CORE_DIR+"/test_resources/firefox_user_agent_strings.yaml", true);
@@ -90,17 +111,15 @@ TEST(BrowserVersion, pgts_browser_list) {
   test_browser_or_os(UA_CORE_DIR+"/test_resources/pgts_browser_list.yaml", true);
 }
 
-TEST(OsVersion, test_user_agent_parser_os) {
-  test_browser_or_os(UA_CORE_DIR+"/test_resources/test_user_agent_parser_os.yaml", false);
-}
-
 TEST(OsVersion, additional_os_tests) {
   test_browser_or_os(UA_CORE_DIR+"/test_resources/additional_os_tests.yaml", false);
 }
 
 TEST(DeviceFamily, test_device) {
-  test_device(UA_CORE_DIR+"/test_resources/test_device.yaml");
+  test_device(UA_CORE_DIR+"/tests/test_device.yaml");
 }
+
+
 
 }  // namespace
 

--- a/main.cpp
+++ b/main.cpp
@@ -11,8 +11,9 @@
 # distributed under the License is distributed on an 'AS IS' BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.#include "ua_parser.h"
+# limitations under the License.
 */
+
 
 #include "ua_parser.h"
 

--- a/main.cpp
+++ b/main.cpp
@@ -11,14 +11,14 @@
 # distributed under the License is distributed on an 'AS IS' BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.
+# limitations under the License.#include "ua_parser.h"
 */
 
 #include "ua_parser.h"
 
 int main(int argc, char *argv[]) {
   std::string user_agent_string("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/30.0.1599.114 Chrome/30.0.1599.114 Safari/537.36");
-  std::string yaml_file("../regexes.yaml");
+  std::string yaml_file("../uap-core/gexes.yaml");
 
   if (argc>1 && std::string(argv[1])=="--help") {
     std::cout << "Usage: ua_parser_cli [user agent string] [regexes.yaml]" << std::endl;


### PR DESCRIPTION
Hi there,

Two issues not yet solved:
1. There are placeholder leftovers after replacing (just for device.* properties).
2. Device tests passed: 15318/15948  uap-core/tests/test_device.yaml.

I have tried regex and regex_search flags and compared to the uap-python impl (which seem to pass all tests)
If you have any ideas/directions ...

Anyway, It would be great if you could merge.

cheers
